### PR TITLE
Add more trophy related requests 

### DIFF
--- a/src/Gumer/PSN/Requests/TrophyDataListRequest.php
+++ b/src/Gumer/PSN/Requests/TrophyDataListRequest.php
@@ -1,0 +1,43 @@
+<?php namespace Gumer\PSN\Requests;
+
+class TrophyDataListRequest extends AbstractAuthenticatedRequest {
+
+	/**
+	 * @var string
+	 */
+	protected $uri = 'https://{{region}}-tpy.np.community.playstation.net/trophy/v1/trophyTitles/{{npCommunicationId}}/trophyGroups/{{groupId}}/trophies?fields=%40default,trophyRare,trophyEarnedRate&npLanguage={{lang}}';
+
+	/**
+	 * @param array
+	 */
+	protected $params = array('lang' => 'en');
+
+	/**
+	 * @param string $communicationId
+	 * @return void
+	 */
+	public function setCommunicationId($communicationId)
+	{
+		$this->params['npCommunicationId'] = (string) $communicationId;
+	}
+
+	/**
+	 * @param string $groupId
+	 * @return void
+	 */
+	public function setGroupId($groupId)
+	{
+		$this->params['groupId'] = (string) $groupId;
+	}
+
+	/**
+	 * @param string $value
+	 * @return void
+	 */
+	public function setLang($value)
+	{
+		$this->params['lang'] = mb_strtolower($value);
+		$this->user()->setLang(mb_strtolower($value));
+	}
+
+}

--- a/src/Gumer/PSN/Requests/TrophyGroupListRequest.php
+++ b/src/Gumer/PSN/Requests/TrophyGroupListRequest.php
@@ -1,0 +1,34 @@
+<?php namespace Gumer\PSN\Requests;
+
+class TrophyGroupListRequest extends AbstractAuthenticatedRequest {
+
+	/**
+	 * @var string
+	 */
+	protected $uri = 'https://{{region}}-tpy.np.community.playstation.net/trophy/v1/trophyTitles/{{npCommunicationId}}/trophyGroups/?npLanguage={{lang}}';
+
+	/**
+	 * @param array
+	 */
+	protected $params = array('lang' => 'en');
+
+	/**
+	 * @param string $communicationId
+	 * @return void
+	 */
+	public function setCommunicationId($communicationId)
+	{
+		$this->params['npCommunicationId'] = (string) $communicationId;
+	}
+
+	/**
+	 * @param string $value
+	 * @return void
+	 */
+	public function setLang($value)
+	{
+		$this->params['lang'] = mb_strtolower($value);
+		$this->user()->setLang(mb_strtolower($value));
+	}
+
+}

--- a/src/Gumer/PSN/Requests/TrophyInfoRequest.php
+++ b/src/Gumer/PSN/Requests/TrophyInfoRequest.php
@@ -1,0 +1,52 @@
+<?php namespace Gumer\PSN\Requests;
+
+class TrophyInfoRequest extends AbstractAuthenticatedRequest {
+
+	/**
+	 * @var string
+	 */
+	protected $uri = 'https://{{region}}-tpy.np.community.playstation.net/trophy/v1/trophyTitles/{{npCommunicationId}}/trophyGroups/{{groupId}}/trophies/{{trophyID}}?fields=%40default,trophyRare,trophyEarnedRate&npLanguage={{lang}}';
+
+	/**
+	 * @param array
+	 */
+	protected $params = array('lang' => 'en');
+
+	/**
+	 * @param string $communicationId
+	 * @return void
+	 */
+	public function setCommunicationId($communicationId)
+	{
+		$this->params['npCommunicationId'] = (string) $communicationId;
+	}
+
+	/**
+	 * @param string $groupId
+	 * @return void
+	 */
+	public function setGroupId($groupId)
+	{
+		$this->params['groupId'] = (string) $groupId;
+	}
+
+	/**
+	 * @param string $trophyId
+	 * @return void
+	 */
+	public function setTrophyId($trophyId)
+	{
+		$this->params['trophyID'] = (string) $trophyId;
+	}
+
+	/**
+	 * @param string $value
+	 * @return void
+	 */
+	public function setLang($value)
+	{
+		$this->params['lang'] = mb_strtolower($value);
+		$this->user()->setLang(mb_strtolower($value));
+	}
+
+}


### PR DESCRIPTION
While developing an application, I noticed the requests for the following data were missing:

- Trophy groups per game/communication id
- Trophy lists per game/communication id and group id
- Trophy info per game/communication id, group id and trophy id

The according URLs are taken from:

https://github.com/jhewt/gumer-psn/blob/68565a464654342a4f3c6f35607b111ef2db4571/psn.js#L53