### PR TITLE
Switch composer package to guzzlehttp/guzzle 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"guzzle/guzzle": "3.8.*@dev",
+		"guzzlehttp/guzzle": "3.8.*@dev",
 		"illuminate/support": "~5"
 	},
 	"require-dev": {


### PR DESCRIPTION
Composer always displays this warning:

> Package guzzle/guzzle is abandoned, you should avoid using it. Use guzzlehttp/guzzle instead.